### PR TITLE
edited the CI github action to run only when the branch is not master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,21 +1,14 @@
 name: CI
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    branches-ignore: [ master ]
 
 jobs:
-  # This workflow contains a single job called "build"
   test:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
       - name: install modules


### PR DESCRIPTION
When the branch IS master, then the more intensive "deploy" action will
be run, which builds, tests, and deploys the application. Thus, running
this CI action on top of that is superfluous, a waste of resources, and
distracting in the action feed.